### PR TITLE
fix: add job_tags: create to Daily Demo F5 Create/Remove workflow node (closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - (Issue #13) Correct credential name on `Day 2 - lb pool check` and `Day 2 - Linux Patching` templates (`Network F5` → `Daily Demo F5 Network`) — pending test environment validation
 - (Issue #14) ✅ Consolidate 6 individual workflow files into single `controller_workflow_job_templates.yml` to prevent `include_vars: dir:` key overwrite — validated in dev: all 6 workflows confirmed created on setup
+- (Issue #18) Add `job_tags: create` to `Daily Demo F5 Create/Remove` node in `Run workflow for the f5 Daily Demo` — prevents both create and remove tags running simultaneously, which caused subnet lookup failure during VM provisioning
 
 ### Added
 - (Issue #15) Post-setup validation play in `setup_demo.yml` — queries AAP API to assert all expected job templates and workflows exist before exiting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- (Issue #13) Correct credential name on `Day 2 - lb pool check` and `Day 2 - Linux Patching` templates (`Network F5` → `Daily Demo F5 Network`)
-- (Issue #14) Consolidate 6 individual workflow files into single `controller_workflow_job_templates.yml` to prevent `include_vars: dir:` key overwrite — all 6 workflows now created on setup
+- (Issue #13) Correct credential name on `Day 2 - lb pool check` and `Day 2 - Linux Patching` templates (`Network F5` → `Daily Demo F5 Network`) — pending test environment validation
+- (Issue #14) ✅ Consolidate 6 individual workflow files into single `controller_workflow_job_templates.yml` to prevent `include_vars: dir:` key overwrite — validated in dev: all 6 workflows confirmed created on setup
 
 ### Added
 - (Issue #15) Post-setup validation play in `setup_demo.yml` — queries AAP API to assert all expected job templates and workflows exist before exiting

--- a/playbooks/files/config_as_code/controller_workflow_job_templates.yml
+++ b/playbooks/files/config_as_code/controller_workflow_job_templates.yml
@@ -163,6 +163,7 @@ controller_workflows:
         workflow_job_template: Run workflow for the f5 Daily Demo
         unified_job_template: Daily Demo F5 Create/Remove
         limit: ""
+        job_tags: create
         organization: IT Service Automation
         all_parents_must_converge: "False"
         success_nodes:


### PR DESCRIPTION
## Summary
- Adds `job_tags: create` to the `Daily Demo F5 Create/Remove` node in the `Run workflow for the f5 Daily Demo` workflow definition

## Root Cause
Without an explicit tag, the node ran with both `create` and `remove` tags simultaneously. It created the VPC and subnet, then immediately removed them, then failed when the VM role tried to look up the subnet ID.

## Fix
One line added to `controller_workflow_job_templates.yml`:
```yaml
job_tags: create
```

## Test Plan
- [ ] Merge and run `Setup - f5 Daily Demo - CAC` to update the workflow in AAP
- [ ] Re-run `Run workflow for the f5 Daily Demo`
- [ ] Confirm F5 infrastructure is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)