### PR TITLE
fix: add missing extra_vars to Daily Demo F5 website template (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - (Issue #13) Correct credential name on `Day 2 - lb pool check` and `Day 2 - Linux Patching` templates (`Network F5` → `Daily Demo F5 Network`) — pending test environment validation
 - (Issue #14) ✅ Consolidate 6 individual workflow files into single `controller_workflow_job_templates.yml` to prevent `include_vars: dir:` key overwrite — validated in dev: all 6 workflows confirmed created on setup
 - (Issue #18) Add `job_tags: create` to `Daily Demo F5 Create/Remove` node in `Run workflow for the f5 Daily Demo` — prevents both create and remove tags running simultaneously, which caused subnet lookup failure during VM provisioning
+- (Issue #21) Add `my_remote_vault`, `my_remote_ssh_pub_key`, and `ansible_python_interpreter` extra vars to `Daily Demo F5 website` template — role `remote_vault` requires `my_remote_vault` to fetch vaulted variables
 
 ### Added
 - (Issue #15) Post-setup validation play in `setup_demo.yml` — queries AAP API to assert all expected job templates and workflows exist before exiting

--- a/playbooks/files/config_as_code/controller_templates.yml
+++ b/playbooks/files/config_as_code/controller_templates.yml
@@ -209,6 +209,10 @@ controller_templates:
     playbook: playbooks/website_setup.yml
     credentials:
       - "{{ my_aws_machine_credential }}"
+    extra_vars:
+      my_remote_vault: "{{ my_remote_vault }}"
+      my_remote_ssh_pub_key: "{{ my_remote_ssh_pub_key }}"
+      ansible_python_interpreter: /usr/bin/python3
 
   - name: "Day 2 - connection test"
     job_type: run


### PR DESCRIPTION
## Summary

- Adds `my_remote_vault`, `my_remote_ssh_pub_key`, and `ansible_python_interpreter` extra vars to `Daily Demo F5 website` template in `controller_templates.yml`
- The `remote_vault` role requires `my_remote_vault` to fetch vaulted variables; without it the job fails immediately
- Matches the pattern already used by `Daily Demo F5 Create/Remove`

## Test plan

- [ ] Run `Setup - f5 Daily Demo - CAC` to apply the updated template
- [ ] Launch `Run workflow for the f5 Daily Demo`
- [ ] Confirm `Daily Demo F5 website` node completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)