### PR TITLE
fix: add vault credential to Daily Demo F5 website template (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - (Issue #14) ✅ Consolidate 6 individual workflow files into single `controller_workflow_job_templates.yml` to prevent `include_vars: dir:` key overwrite — validated in dev: all 6 workflows confirmed created on setup
 - (Issue #18) Add `job_tags: create` to `Daily Demo F5 Create/Remove` node in `Run workflow for the f5 Daily Demo` — prevents both create and remove tags running simultaneously, which caused subnet lookup failure during VM provisioning
 - (Issue #21) Add `my_remote_vault`, `my_remote_ssh_pub_key`, and `ansible_python_interpreter` extra vars to `Daily Demo F5 website` template — role `remote_vault` requires `my_remote_vault` to fetch vaulted variables
+- (Issue #23) Add `{{ my_aap_credential }}` to `Daily Demo F5 website` credentials — vault credential required to decrypt the remote vault file
 
 ### Added
 - (Issue #15) Post-setup validation play in `setup_demo.yml` — queries AAP API to assert all expected job templates and workflows exist before exiting

--- a/playbooks/files/config_as_code/controller_templates.yml
+++ b/playbooks/files/config_as_code/controller_templates.yml
@@ -209,6 +209,7 @@ controller_templates:
     playbook: playbooks/website_setup.yml
     credentials:
       - "{{ my_aws_machine_credential }}"
+      - "{{ my_aap_credential }}"
     extra_vars:
       my_remote_vault: "{{ my_remote_vault }}"
       my_remote_ssh_pub_key: "{{ my_remote_ssh_pub_key }}"


### PR DESCRIPTION
## Summary

- Adds `{{ my_aap_credential }}` to `Daily Demo F5 website` credentials list
- The `remote_vault` role decrypts a vaulted variables file — without a vault credential AAP has no secrets to decrypt with
- Matches the pattern used by `Daily Demo F5 Create/Remove`

## Test plan

- [ ] Run `Setup - f5 Daily Demo - CAC` to apply updated template
- [ ] Launch `Run workflow for the f5 Daily Demo`
- [ ] Confirm `Daily Demo F5 website` node passes the `remote_vault : Include configurations` task

🤖 Generated with [Claude Code](https://claude.com/claude-code)